### PR TITLE
0.1.1 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "constmuck"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["rodrimati1992 <rodrimatt1985@gmail.com>"]
 edition = "2021"
 license = "Zlib"

--- a/src/copying.rs
+++ b/src/copying.rs
@@ -1,6 +1,8 @@
 //! For copying values in generic contexts.
 //!
+//!
 //! Related: [`ImplsCopy`] type, [`type_size`] macro.
+#![allow(deprecated)]
 
 use core::{marker::PhantomData, mem::MaybeUninit};
 
@@ -13,6 +15,19 @@ pub(crate) mod impls_copy {
     /// avoids requiring (unstable as of 2021) trait bounds in `const fn`s.
     ///
     /// Related: the [`copying`](crate::copying) module
+    ///
+    /// # Deprecation
+    ///
+    /// Copying `&T` with the approach constmuck uses
+    /// (an intermediate `MaybeUninit<[u8; N]>`)
+    /// isn't settled as being sound,
+    /// so [`ImplsCopy`] will require [`Pod`] in the 0.2.0 version.
+    ///
+    /// If there's a more permissive bound that allows more non-pointer-containing
+    /// `Copy` types, `ImplsCopy` will be changed to use that.
+    ///
+    /// [`Pod`]: bytemuck::Pod
+    #[deprecated(since = "0.1.1", note = "too permissive in what it allows copying")]
     pub struct ImplsCopy<T> {
         _private: PhantomData<fn() -> T>,
     }


### PR DESCRIPTION
-  Deprecated ImplsCopy to alert potential unsoundness fixed in 0.2.0.